### PR TITLE
Added public compiled assets to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,4 +218,8 @@ GitHub.sublime-settings
 /node_modules
 /yarn-error.log
 
+# Ignore compiled assets
+/public/assets
+/public/assets/*
+
 .byebug_history


### PR DESCRIPTION
From now on run `rails assets:precompile` to compile assets for testing locally
We will by default ignore compiled assets to keep dynamic compiled files out of everyone's commits