### PR TITLE
So previously I meant to add an index for attachment tables but a sma…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.1)
+    loofah (2.2.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.12)
@@ -125,7 +125,7 @@ GEM
       ruby-progressbar
     multi_json (1.13.1)
     nenv (0.3.0)
-    nio4r (2.3.0)
+    nio4r (2.2.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.0)
+    loofah (2.2.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.12)
@@ -125,7 +125,7 @@ GEM
       ruby-progressbar
     multi_json (1.13.1)
     nenv (0.3.0)
-    nio4r (2.2.0)
+    nio4r (2.3.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,5 +1,5 @@
 class Course < ApplicationRecord
-  has_many :attachments, as: :attachables, dependent: :destroy
+  has_many :attachments, as: :attacheables, dependent: :destroy
   belongs_to :user
   alias_attribute :creator, :user
   has_many :enrollments, dependent: :destroy

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,5 +1,5 @@
 class Course < ApplicationRecord
-  has_many :attachments, as: :attacheables, dependent: :destroy
+  has_many :attachments, as: :attachables, dependent: :destroy
   belongs_to :user
   alias_attribute :creator, :user
   has_many :enrollments, dependent: :destroy

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,5 +1,5 @@
 class Document < ApplicationRecord
-  belongs_to :attacheable, polymorphic: true
+  belongs_to :attachable, polymorphic: true
   belongs_to :user
   alias_attribute :creator, :user
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,5 +1,5 @@
 class Document < ApplicationRecord
-  belongs_to :attachable, polymorphic: true
+  belongs_to :attacheable, polymorphic: true
   belongs_to :user
   alias_attribute :creator, :user
 end

--- a/app/models/embed.rb
+++ b/app/models/embed.rb
@@ -1,5 +1,5 @@
 class Embed < ApplicationRecord
-  belongs_to :attachable, polymorphic: true
+  belongs_to :attacheable, polymorphic: true
   belongs_to :user
   alias_attribute :creator, :user
 end

--- a/app/models/embed.rb
+++ b/app/models/embed.rb
@@ -1,5 +1,5 @@
 class Embed < ApplicationRecord
-  belongs_to :attacheable, polymorphic: true
+  belongs_to :attachable, polymorphic: true
   belongs_to :user
   alias_attribute :creator, :user
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,5 +1,5 @@
 class Text < ApplicationRecord
-  belongs_to :attachable, polymorphic: true
+  belongs_to :attacheable, polymorphic: true
   belongs_to :user
   alias_attribute :creator, :user
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,5 +1,5 @@
 class Text < ApplicationRecord
-  belongs_to :attacheable, polymorphic: true
+  belongs_to :attachable, polymorphic: true
   belongs_to :user
   alias_attribute :creator, :user
 end

--- a/db/migrate/20180318231434_create_files.rb
+++ b/db/migrate/20180318231434_create_files.rb
@@ -6,6 +6,6 @@ class CreateFiles < ActiveRecord::Migration[5.1]
       t.references :attacheable, null: false, polymorphic: true
       t.integer :display_index
     end
-    add_index(:files, [:attacheable, :attacheable_type])
+    add_index(:files, [:attacheable_id, :attacheable_type], name: "index_files_on_attacheable_and_attacheable_type")
   end
 end

--- a/db/migrate/20180318231434_create_files.rb
+++ b/db/migrate/20180318231434_create_files.rb
@@ -3,9 +3,9 @@ class CreateFiles < ActiveRecord::Migration[5.1]
     create_table :files do |t|
       t.string :title, default: "Untitled", null: false
       t.references :user, null: false, index: true
-      t.references :attacheable, null: false, polymorphic: true
+      t.references :attachable, null: false, polymorphic: true
       t.integer :display_index
     end
-    add_index(:files, [:attacheable_id, :attacheable_type], name: "index_files_on_attacheable_and_attacheable_type")
+    add_index(:files, [:attachable_id, :attachable_type], name: "index_files_on_attachable_and_attachable_type")
   end
 end

--- a/db/migrate/20180318231434_create_files.rb
+++ b/db/migrate/20180318231434_create_files.rb
@@ -3,9 +3,9 @@ class CreateFiles < ActiveRecord::Migration[5.1]
     create_table :files do |t|
       t.string :title, default: "Untitled", null: false
       t.references :user, null: false, index: true
-      t.references :attachable, null: false, polymorphic: true
+      t.references :attacheable, null: false, polymorphic: true
       t.integer :display_index
     end
-    add_index(:files, [:attachable_id, :attachable_type], name: "index_files_on_attachable_and_attachable_type")
+    add_index(:files, [:attacheable_id, :attacheable_type], name: "index_files_on_attacheable_and_attacheable_type")
   end
 end

--- a/db/migrate/20180318232417_create_embeds.rb
+++ b/db/migrate/20180318232417_create_embeds.rb
@@ -2,10 +2,10 @@ class CreateEmbeds < ActiveRecord::Migration[5.1]
   def change
     create_table :embeds do |t|
       t.references :user, null: false
-      t.references :attachable, null: false, polymorphic: true
+      t.references :attacheable, null: false, polymorphic: true
       t.text :content
       t.integer :display_index
     end
-    add_index(:embeds, [:attachable, :attachable_type], name: "index_embeds_on_attachable_and_attachable_type")
+    add_index(:embeds, [:attacheable, :attacheable_type], name: "index_embeds_on_attacheable_and_attacheable_type")
   end
 end

--- a/db/migrate/20180318232417_create_embeds.rb
+++ b/db/migrate/20180318232417_create_embeds.rb
@@ -2,10 +2,10 @@ class CreateEmbeds < ActiveRecord::Migration[5.1]
   def change
     create_table :embeds do |t|
       t.references :user, null: false
-      t.references :attacheable, null: false, polymorphic: true
+      t.references :attachable, null: false, polymorphic: true
       t.text :content
       t.integer :display_index
     end
-    add_index(:embeds, [:attacheable, :attacheable_type], name: "index_embeds_on_attacheable_and_attacheable_type")
+    add_index(:embeds, [:attachable, :attachable_type], name: "index_embeds_on_attachable_and_attachable_type")
   end
 end

--- a/db/migrate/20180318232417_create_embeds.rb
+++ b/db/migrate/20180318232417_create_embeds.rb
@@ -6,6 +6,6 @@ class CreateEmbeds < ActiveRecord::Migration[5.1]
       t.text :content
       t.integer :display_index
     end
-    add_index(:embeds, [:attacheable, :attacheable_type])
+    add_index(:embeds, [:attacheable, :attacheable_type], name: "index_embeds_on_attacheable_and_attacheable_type")
   end
 end

--- a/db/migrate/20180318232437_create_texts.rb
+++ b/db/migrate/20180318232437_create_texts.rb
@@ -2,10 +2,10 @@ class CreateTexts < ActiveRecord::Migration[5.1]
   def change
     create_table :texts do |t|
       t.references :user, null: false
-      t.references :attacheable, null: false, polymorphic: true
+      t.references :attachable, null: false, polymorphic: true
       t.text :content
       t.integer :display_index
     end
-    add_index(:texts, [:attacheable, :attacheable_type], name: "index_texts_on_attacheable_and_attacheable_type")
+    add_index(:texts, [:attachable, :attachable_type], name: "index_texts_on_attachable_and_attachable_type")
   end
 end

--- a/db/migrate/20180318232437_create_texts.rb
+++ b/db/migrate/20180318232437_create_texts.rb
@@ -2,10 +2,10 @@ class CreateTexts < ActiveRecord::Migration[5.1]
   def change
     create_table :texts do |t|
       t.references :user, null: false
-      t.references :attachable, null: false, polymorphic: true
+      t.references :attacheable, null: false, polymorphic: true
       t.text :content
       t.integer :display_index
     end
-    add_index(:texts, [:attachable, :attachable_type], name: "index_texts_on_attachable_and_attachable_type")
+    add_index(:texts, [:attacheable, :attacheable_type], name: "index_texts_on_attacheable_and_attacheable_type")
   end
 end

--- a/db/migrate/20180318232437_create_texts.rb
+++ b/db/migrate/20180318232437_create_texts.rb
@@ -6,6 +6,6 @@ class CreateTexts < ActiveRecord::Migration[5.1]
       t.text :content
       t.integer :display_index
     end
-    add_index(:texts, [:attacheable, :attacheable_type])
+    add_index(:texts, [:attacheable, :attacheable_type], name: "index_texts_on_attacheable_and_attacheable_type")
   end
 end

--- a/db/migrate/20180319020156_drop_files.rb
+++ b/db/migrate/20180319020156_drop_files.rb
@@ -4,9 +4,9 @@ class DropFiles < ActiveRecord::Migration[5.1]
     create_table :documents do |t|
       t.string :title, default: "Untitled", null: false
       t.references :user, null: false, index: true
-      t.references :attacheable, null: false, polymorphic: true
+      t.references :attachable, null: false, polymorphic: true
       t.integer :display_index
     end
-    add_index(:documents, [:attacheable_id, :attacheable_type], name: "index_documents_on_attacheable_and_attacheable_type")
+    add_index(:documents, [:attachable_id, :attachable_type], name: "index_documents_on_attachable_and_attachable_type")
   end
 end

--- a/db/migrate/20180319020156_drop_files.rb
+++ b/db/migrate/20180319020156_drop_files.rb
@@ -7,6 +7,6 @@ class DropFiles < ActiveRecord::Migration[5.1]
       t.references :attacheable, null: false, polymorphic: true
       t.integer :display_index
     end
-    add_index(:documents, [:attacheable, :attacheable_type])
+    add_index(:documents, [:attacheable_id, :attacheable_type], name: "index_documents_on_attacheable_and_attacheable_type")
   end
 end

--- a/db/migrate/20180319020156_drop_files.rb
+++ b/db/migrate/20180319020156_drop_files.rb
@@ -4,9 +4,9 @@ class DropFiles < ActiveRecord::Migration[5.1]
     create_table :documents do |t|
       t.string :title, default: "Untitled", null: false
       t.references :user, null: false, index: true
-      t.references :attachable, null: false, polymorphic: true
+      t.references :attacheable, null: false, polymorphic: true
       t.integer :display_index
     end
-    add_index(:documents, [:attachable_id, :attachable_type], name: "index_documents_on_attachable_and_attachable_type")
+    add_index(:documents, [:attacheable_id, :attacheable_type], name: "index_documents_on_attacheable_and_attacheable_type")
   end
 end

--- a/db/migrate/20180320021915_reindex_attacheables.rb
+++ b/db/migrate/20180320021915_reindex_attacheables.rb
@@ -1,7 +1,7 @@
-class ReindexAttacheables < ActiveRecord::Migration[5.1]
+class Reindexattachables < ActiveRecord::Migration[5.1]
   def change
-    remove_index(:documents, name: "index_documents_on_attacheable_and_attacheable_type")
-    remove_index(:texts, name: "index_texts_on_attacheable_and_attacheable_type")
-    remove_index(:embeds, name: "index_embeds_on_attacheable_and_attacheable_type")
+    remove_index(:documents, name: "index_documents_on_attachable_and_attachable_type")
+    remove_index(:texts, name: "index_texts_on_attachable_and_attachable_type")
+    remove_index(:embeds, name: "index_embeds_on_attachable_and_attachable_type")
   end
 end

--- a/db/migrate/20180320021915_reindex_attacheables.rb
+++ b/db/migrate/20180320021915_reindex_attacheables.rb
@@ -1,0 +1,7 @@
+class ReindexAttacheables < ActiveRecord::Migration[5.1]
+  def change
+    remove_index(:documents, name: "index_documents_on_attacheable_and_attacheable_type")
+    remove_index(:texts, name: "index_texts_on_attacheable_and_attacheable_type")
+    remove_index(:embeds, name: "index_embeds_on_attacheable_and_attacheable_type")
+  end
+end

--- a/db/migrate/20180320021915_reindex_attacheables.rb
+++ b/db/migrate/20180320021915_reindex_attacheables.rb
@@ -1,7 +1,7 @@
-class Reindexattachables < ActiveRecord::Migration[5.1]
+class ReindexAttacheables < ActiveRecord::Migration[5.1]
   def change
-    remove_index(:documents, name: "index_documents_on_attachable_and_attachable_type")
-    remove_index(:texts, name: "index_texts_on_attachable_and_attachable_type")
-    remove_index(:embeds, name: "index_embeds_on_attachable_and_attachable_type")
+    remove_index(:documents, name: "index_documents_on_attacheable_and_attacheable_type")
+    remove_index(:texts, name: "index_texts_on_attacheable_and_attacheable_type")
+    remove_index(:embeds, name: "index_embeds_on_attacheable_and_attacheable_type")
   end
 end

--- a/db/migrate/20180327011655_rename_attacheable_to_attachable.rb
+++ b/db/migrate/20180327011655_rename_attacheable_to_attachable.rb
@@ -1,0 +1,16 @@
+class RenameAttacheableToAttachable < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :documents, name: :index_documents_on_attacheable_type_and_attacheable_id
+    remove_index :embeds, name: :index_embeds_on_attacheable_type_and_attacheable_id
+    remove_index :texts, name: :index_texts_on_attacheable_type_and_attacheable_id
+    rename_column(:documents, :attacheable_id, :attachable_id)
+    rename_column(:documents, :attacheable_type, :attachable_type)
+    rename_column(:embeds, :attacheable_id, :attachable_id)
+    rename_column(:embeds, :attacheable_type, :attachable_type)
+    rename_column(:texts, :attacheable_id, :attachable_id)
+    rename_column(:texts, :attacheable_type, :attachable_type)
+    add_index(:documents, [:attachable_type, :attachable_id], unique: true, name: "index_documents_on_attachable_type_and_attachable_id")
+    add_index(:embeds, [:attachable_type, :attachable_id], unique: true, name: "index_embeds_on_attachable_type_and_attachable_id")
+    add_index(:texts, [:attachable_type, :attachable_id], unique: true, name: "index_texts_on_attachable_type_and_attachable_id")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,20 +27,20 @@ ActiveRecord::Schema.define(version: 20180320021915) do
   create_table "documents", force: :cascade do |t|
     t.string "title", default: "Untitled", null: false
     t.integer "user_id", null: false
-    t.string "attacheable_type", null: false
-    t.integer "attacheable_id", null: false
+    t.string "attachable_type", null: false
+    t.integer "attachable_id", null: false
     t.integer "display_index"
-    t.index ["attacheable_type", "attacheable_id"], name: "index_documents_on_attacheable_type_and_attacheable_id"
+    t.index ["attachable_type", "attachable_id"], name: "index_documents_on_attachable_type_and_attachable_id"
     t.index ["user_id"], name: "index_documents_on_user_id"
   end
 
   create_table "embeds", force: :cascade do |t|
     t.integer "user_id", null: false
-    t.string "attacheable_type", null: false
-    t.integer "attacheable_id", null: false
+    t.string "attachable_type", null: false
+    t.integer "attachable_id", null: false
     t.text "content", default: "", null: false
     t.integer "display_index", default: 0, null: false
-    t.index ["attacheable_type", "attacheable_id"], name: "index_embeds_on_attacheable_type_and_attacheable_id"
+    t.index ["attachable_type", "attachable_id"], name: "index_embeds_on_attachable_type_and_attachable_id"
     t.index ["user_id"], name: "index_embeds_on_user_id"
   end
 
@@ -56,11 +56,11 @@ ActiveRecord::Schema.define(version: 20180320021915) do
 
   create_table "texts", force: :cascade do |t|
     t.integer "user_id", null: false
-    t.string "attacheable_type", null: false
-    t.integer "attacheable_id", null: false
+    t.string "attachable_type", null: false
+    t.integer "attachable_id", null: false
     t.text "content", default: "", null: false
     t.integer "display_index", default: 0, null: false
-    t.index ["attacheable_type", "attacheable_id"], name: "index_texts_on_attacheable_type_and_attacheable_id"
+    t.index ["attachable_type", "attachable_id"], name: "index_texts_on_attachable_type_and_attachable_id"
     t.index ["user_id"], name: "index_texts_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180319020156) do
+ActiveRecord::Schema.define(version: 20180320021915) do
 
   create_table "courses", force: :cascade do |t|
     t.string "title", default: "Untitled", null: false
@@ -32,7 +32,6 @@ ActiveRecord::Schema.define(version: 20180319020156) do
     t.integer "display_index"
     t.index ["attacheable_type", "attacheable_id"], name: "index_documents_on_attacheable_type_and_attacheable_id"
     t.index ["user_id"], name: "index_documents_on_user_id"
-    t.index [nil, "attacheable_type"], name: "index_documents_on_attacheable_and_attacheable_type"
   end
 
   create_table "embeds", force: :cascade do |t|
@@ -42,7 +41,6 @@ ActiveRecord::Schema.define(version: 20180319020156) do
     t.text "content", default: "", null: false
     t.integer "display_index", default: 0, null: false
     t.index ["attacheable_type", "attacheable_id"], name: "index_embeds_on_attacheable_type_and_attacheable_id"
-    t.index ["attacheable_type"], name: "index_embeds_on_attacheable_and_attacheable_type"
     t.index ["user_id"], name: "index_embeds_on_user_id"
   end
 
@@ -63,7 +61,6 @@ ActiveRecord::Schema.define(version: 20180319020156) do
     t.text "content", default: "", null: false
     t.integer "display_index", default: 0, null: false
     t.index ["attacheable_type", "attacheable_id"], name: "index_texts_on_attacheable_type_and_attacheable_id"
-    t.index ["attacheable_type"], name: "index_texts_on_attacheable_and_attacheable_type"
     t.index ["user_id"], name: "index_texts_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180320021915) do
+ActiveRecord::Schema.define(version: 20180327011655) do
 
   create_table "courses", force: :cascade do |t|
     t.string "title", default: "Untitled", null: false
@@ -27,20 +27,20 @@ ActiveRecord::Schema.define(version: 20180320021915) do
   create_table "documents", force: :cascade do |t|
     t.string "title", default: "Untitled", null: false
     t.integer "user_id", null: false
-    t.string "attacheable_type", null: false
-    t.integer "attacheable_id", null: false
+    t.string "attachable_type", null: false
+    t.integer "attachable_id", null: false
     t.integer "display_index"
-    t.index ["attacheable_type", "attacheable_id"], name: "index_documents_on_attacheable_type_and_attacheable_id"
+    t.index ["attachable_type", "attachable_id"], name: "index_documents_on_attachable_type_and_attachable_id", unique: true
     t.index ["user_id"], name: "index_documents_on_user_id"
   end
 
   create_table "embeds", force: :cascade do |t|
     t.integer "user_id", null: false
-    t.string "attacheable_type", null: false
-    t.integer "attacheable_id", null: false
+    t.string "attachable_type", null: false
+    t.integer "attachable_id", null: false
     t.text "content", default: "", null: false
     t.integer "display_index", default: 0, null: false
-    t.index ["attacheable_type", "attacheable_id"], name: "index_embeds_on_attacheable_type_and_attacheable_id"
+    t.index ["attachable_type", "attachable_id"], name: "index_embeds_on_attachable_type_and_attachable_id", unique: true
     t.index ["user_id"], name: "index_embeds_on_user_id"
   end
 
@@ -56,11 +56,11 @@ ActiveRecord::Schema.define(version: 20180320021915) do
 
   create_table "texts", force: :cascade do |t|
     t.integer "user_id", null: false
-    t.string "attacheable_type", null: false
-    t.integer "attacheable_id", null: false
+    t.string "attachable_type", null: false
+    t.integer "attachable_id", null: false
     t.text "content", default: "", null: false
     t.integer "display_index", default: 0, null: false
-    t.index ["attacheable_type", "attacheable_id"], name: "index_texts_on_attacheable_type_and_attacheable_id"
+    t.index ["attachable_type", "attachable_id"], name: "index_texts_on_attachable_type_and_attachable_id", unique: true
     t.index ["user_id"], name: "index_texts_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,20 +27,20 @@ ActiveRecord::Schema.define(version: 20180320021915) do
   create_table "documents", force: :cascade do |t|
     t.string "title", default: "Untitled", null: false
     t.integer "user_id", null: false
-    t.string "attachable_type", null: false
-    t.integer "attachable_id", null: false
+    t.string "attacheable_type", null: false
+    t.integer "attacheable_id", null: false
     t.integer "display_index"
-    t.index ["attachable_type", "attachable_id"], name: "index_documents_on_attachable_type_and_attachable_id"
+    t.index ["attacheable_type", "attacheable_id"], name: "index_documents_on_attacheable_type_and_attacheable_id"
     t.index ["user_id"], name: "index_documents_on_user_id"
   end
 
   create_table "embeds", force: :cascade do |t|
     t.integer "user_id", null: false
-    t.string "attachable_type", null: false
-    t.integer "attachable_id", null: false
+    t.string "attacheable_type", null: false
+    t.integer "attacheable_id", null: false
     t.text "content", default: "", null: false
     t.integer "display_index", default: 0, null: false
-    t.index ["attachable_type", "attachable_id"], name: "index_embeds_on_attachable_type_and_attachable_id"
+    t.index ["attacheable_type", "attacheable_id"], name: "index_embeds_on_attacheable_type_and_attacheable_id"
     t.index ["user_id"], name: "index_embeds_on_user_id"
   end
 
@@ -56,11 +56,11 @@ ActiveRecord::Schema.define(version: 20180320021915) do
 
   create_table "texts", force: :cascade do |t|
     t.integer "user_id", null: false
-    t.string "attachable_type", null: false
-    t.integer "attachable_id", null: false
+    t.string "attacheable_type", null: false
+    t.integer "attacheable_id", null: false
     t.text "content", default: "", null: false
     t.integer "display_index", default: 0, null: false
-    t.index ["attachable_type", "attachable_id"], name: "index_texts_on_attachable_type_and_attachable_id"
+    t.index ["attacheable_type", "attacheable_id"], name: "index_texts_on_attacheable_type_and_attacheable_id"
     t.index ["user_id"], name: "index_texts_on_user_id"
   end
 


### PR DESCRIPTION
…ll typo messed that up and rails just ran with it and made a broken index. This should fix it.

Edit: fixed typo "attacheable" to "attachable"

*Checking that this works:*
After running `rails db:migrate:reset && rails db:migrate`, you should see in `schema.rb` that there's only 2 indices on the _documents_, _texts_, _embeds_ table (one is for related users and one is for the content it is attached to which in this case is courses) 