### PR TITLE
Some fixes to betafeatures and path helpers

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -73,7 +73,7 @@
               </a>
               <div class="dropdown-menu corners darker-blue-theme borderless" aria-labelledby="navbarDropdown">
                 <a class="dropdown-item darker-blue-theme blue-hover super-padded subtitle" href="/users/<%= current_user.id %>">Profile</a>
-                <%= link_to logout_path, method: :delete, class:"dropdown-item darker-blue-theme blue-hover super-padded subtitle" do %>
+                <%= link_to "/logout", method: :delete, class:"dropdown-item darker-blue-theme blue-hover super-padded subtitle" do %>
                   Log Out
                 <% end %>
               </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -21,7 +21,7 @@
           <% end %>
         </div>
 
-        <% if BetaFeatures.released?(:oauth, current_user) %>
+        <% if BetaFeatures.released?(:oauth, current_user: current_user) %>
           <div class="shadow_box login-apis">
             Log in through a third-party:
             <br>
@@ -36,7 +36,7 @@
 
         <div class="shadow_box">
           New user?
-          <%= link_to signup_path do %>
+          <%= link_to "/signup" do %>
             <button class="button">Sign up now!</button>
           <% end %>
         </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -28,7 +28,7 @@
 
         <div class="shadow_box">
           Already have an account?
-          <%= link_to login_path do %>
+          <%= link_to "/login" do %>
             <button class="button">Log in here!</button>
           <% end %>
         </div>


### PR DESCRIPTION
#### Issue Addressed: No issue, this is  last-minute production fix
#### Changes:
Change header, login, signup and logout to not use path helpers.
This is because our routes are conditionally declared meaning some of these helpers are failing in production due to the route being undefined.

In the future let's prefer to use explicit relative URI's eg `"/login"` instead of `login_path` since explicit paths can be passed without needing the routes declared. (The failed route look-up will just redirect to coming-soon
#### Reviewer: @NotAssigned
