### PR TITLE
Fixed the documentation for beta feature configuration

### DIFF
--- a/app/models/beta_features.rb
+++ b/app/models/beta_features.rb
@@ -3,7 +3,7 @@ class BetaFeatures
   # To track a feature, wrap off of your changes in a condition and register your feature name under the @@features table
 
   # Example wrapper:
-  # if BetaFeatures.released?(:name_of_my_feature)
+  # if BetaFeatures.released?(:name_of_my_feature, current_user: current_user)
   #   ... all of my cool new code ...
   # end
 


### PR DESCRIPTION
This now shows how to wrap beta features optionally passing in the current user allows conditional release to admins on prod.

#### Issue Addressed: [Issue](https://github.com/CodeTheChangeUBC/Chingari)
#### Changes:
Previously the documentation didn't show developers how to add in the optional user param. This means by default their beta features are only conditional on the environment setting. Now they can wrap the features so that they can be accessed on production but only when logged in as an admin user.

However, @bchugg I don't think this mechanism works immediately for testing OAuth login. Does it have to be tested on prod due to the domain name? For your work we may just have to release on prod and test from there. Send me a message on Slack and I'll give you the info you need to deploy changes. That way you can make changes directly if you need to.
#### Reviewer: @bchugg 
