### PR TITLE
Rename top anchor

### DIFF
--- a/app/models/beta_features.rb
+++ b/app/models/beta_features.rb
@@ -3,7 +3,7 @@ class BetaFeatures
   # To track a feature, wrap off of your changes in a condition and register your feature name under the @@features table
 
   # Example wrapper:
-  # if BetaFeatures.released?(:name_of_my_feature)
+  # if BetaFeatures.released?(:name_of_my_feature, current_user: current_user)
   #   ... all of my cool new code ...
   # end
 

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -31,7 +31,7 @@
         <%= image_tag("logos/footer.png", class: "footer-logo") %>
       </a>
       <br>
-      <a href="#top"><i class="fa fa-chevron-up"></i>Back to Top</a>
+      <a href="#page-top"><i class="fa fa-chevron-up"></i>Back to Top</a>
     </div>
   </div>
 </footer>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<a data-anchor-id="top">
+<a data-anchor-id="page-top">
   <div class="header light-theme">
 
     <div class="header-top row text-center">


### PR DESCRIPTION
#### Issue Addressed: [Issue](https://github.com/CodeTheChangeUBC/Chingari)
#### Changes:
I figured out why the back-to-top anchor was jumping instead of scrolling to the top.
`#top` is reserved and implemented in HTML5 so we need to rename it to avoid the browser doing the jump for us.
#### Reviewer: @ErisMik 
